### PR TITLE
🖌 PAPI parsing of boss bar title

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,3 +57,7 @@ sonarqube {
         property "sonar.host.url", "https://sonarcloud.io"
     }
 }
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}

--- a/src/main/java/com/tamrielnetwork/gbooster/bar/BoosterBar.java
+++ b/src/main/java/com/tamrielnetwork/gbooster/bar/BoosterBar.java
@@ -21,6 +21,7 @@ package com.tamrielnetwork.gbooster.bar;
 import com.tamrielnetwork.gbooster.GBooster;
 import com.tamrielnetwork.gbooster.boosters.BoosterType;
 import com.tamrielnetwork.gbooster.utils.Chat;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
@@ -51,7 +52,10 @@ public class BoosterBar {
 			if (main.getActiveBoostersManager().getActiveBoosters().size() == 0) {
 
 				if (main.getConfig().getBoolean("empty-bar")) {
-					bar.setTitle(Chat.replaceColors(Objects.requireNonNull(main.getConfig().getString("default-bar-message"))));
+
+					String defaultBarMessage = main.getConfig().getString("default-bar-message");
+					bar.setTitle(Chat.replaceColors(Objects.requireNonNull(defaultBarMessage)));
+
 				} else {
 					bar.setVisible(false);
 				}
@@ -73,13 +77,25 @@ public class BoosterBar {
 	}
 
 	private String getTitle() {
+		String title = main.getConfig().getString("bar-pattern");
 
-		return Chat.replaceColors(Objects.requireNonNull(main.getConfig().getString("bar-pattern"))
+		title = Chat.replaceColors(Objects.requireNonNull(main.getConfig().getString("bar-pattern"))
 				.replace("%minecraft%", String.valueOf(Math.round((main.getActiveBoostersManager().getBoosterMultiplier(BoosterType.MINECRAFT, false)) * 100)))
 				.replace("%mcmmo%", String.valueOf(Math.round((main.getActiveBoostersManager().getBoosterMultiplier(BoosterType.MCMMO, false)) * 100)))
 				.replace("%jobs_xp%", String.valueOf(Math.round((main.getActiveBoostersManager().getBoosterMultiplier(BoosterType.JOBS_XP, true)) * 100)))
 				.replace("%jobs_money%", String.valueOf(Math.round((main.getActiveBoostersManager().getBoosterMultiplier(BoosterType.JOBS_MONEY, true)) * 100)))
 				.replace("%duration%", String.valueOf(main.getActiveBoostersManager().getMostOldBoosterInMinutes())));
+
+		if (bar != null) {
+			if(bar.getPlayers().size() > 0) {
+				Player somePlayer = bar.getPlayers().get(0);
+				if (somePlayer != null) {
+					title = PlaceholderAPI.setPlaceholders(somePlayer, title);
+				}
+			}
+		}
+
+		return title;
 	}
 
 	public BossBar getBar() {


### PR DESCRIPTION
This PR adds a feature that sets the placeholders used by PlaceholderAPI before displaying the boss bar title. Players will now be able to use PlaceholderAPI placeholders in the `bar-pattern` property of the config.

Example of personal use case: I use [ConditionalTextPlaceholders](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwj2kPOem772AhUPITQIHbqMCHAQFnoECBEQAQ&url=https%3A%2F%2Fwww.spigotmc.org%2Fresources%2Fconditional-text-placeholders.82920%2F&usg=AOvVaw1QGtNQBvoufXQHcqT4tHSX) to parse text differently based on the placeholder. I can pass a specific boost percentage using `%minecraft%`, `%mcmmo%`, etc. from the GBooster config into ConditionalTextPlaceholders to parse an empty string `""` when the value is equal to `100` or the full string otherwise. This, in turn, only renders the parts of the boss bar titles with >100% bonus, to reduce redundancy.

This feature in itself could be a part of the plugin, by the way, to avoid having players to use this as a workaround. If you approve, I'm happy to open an issue or even contribute the change when I have the time.

(Note, apologies: I forgot to remove the extra deps in `build.gradle` 😥)